### PR TITLE
issue#1 | mirai依赖更新至 2.1 版本，修复一个 Config 读取 bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,17 +18,16 @@ version VERSION
 
 repositories {
 	mavenCentral()
+	jcenter()
 	google()
 	maven { url 'https://dl.bintray.com/kotlin/kotlin-eap'}
 	maven { url 'https://jitpack.io' }
-	jcenter()
 }
 
 dependencies {
 	implementation "net.dv8tion:JDA:4.1.1_127"
 	implementation 'com.google.code.gson:gson:2.8.6'
-	compile group: 'net.mamoe', name: 'mirai-core', version: '1.3.3'
-	compile group: 'net.mamoe', name: 'mirai-core-qqandroid', version: '1.3.3'
+	compile group: 'net.mamoe', name: 'mirai-core', version: '2.1.0'
 	implementation "com.typesafe:config:1.4.0"
 	compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.14.0'
 	compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.14.0'

--- a/src/main/java/cc/sukazyo/icee/module/bot/CommonBotMessage.java
+++ b/src/main/java/cc/sukazyo/icee/module/bot/CommonBotMessage.java
@@ -5,10 +5,9 @@ import cc.sukazyo.icee.system.Variable;
 import cc.sukazyo.icee.util.CommandHelper;
 import cc.sukazyo.icee.util.FileHelper;
 import com.google.gson.Gson;
-import kotlin.Unit;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.mamoe.mirai.message.FriendMessageEvent;
-import net.mamoe.mirai.message.GroupMessageEvent;
+import net.mamoe.mirai.event.events.FriendMessageEvent;
+import net.mamoe.mirai.event.events.GroupMessageEvent;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -92,7 +91,7 @@ public class CommonBotMessage {
 		type = Type.MIRAI_GROUP;
 		miraiGroupEvent = event;
 		StringBuilder msgRev = new StringBuilder();
-		event.getMessage().forEachContent(node -> {
+		event.getMessage().forEach(node -> {
 			if (node instanceof net.mamoe.mirai.message.data.Image) {
 				Log.logger.info("IMAGE");
 			} else if (node instanceof net.mamoe.mirai.message.data.PlainText) {
@@ -106,7 +105,6 @@ public class CommonBotMessage {
 			} else {
 				Log.logger.info("UNDEFIENED");
 			}
-			return Unit.INSTANCE;
 		});
 		if(!event.getMessage().contentToString().equals("")) {
 			msgRev.append(event.getMessage().contentToString());

--- a/src/main/java/cc/sukazyo/icee/module/bot/mirai/EventHandle.java
+++ b/src/main/java/cc/sukazyo/icee/module/bot/mirai/EventHandle.java
@@ -3,14 +3,16 @@ package cc.sukazyo.icee.module.bot.mirai;
 import cc.sukazyo.icee.module.bot.CommonBotMessage;
 import cc.sukazyo.icee.system.Log;
 import net.mamoe.mirai.event.EventHandler;
-import net.mamoe.mirai.event.ListenerHost;
+import net.mamoe.mirai.event.SimpleListenerHost;
 import net.mamoe.mirai.event.events.BotOfflineEvent;
 import net.mamoe.mirai.event.events.BotOnlineEvent;
 import net.mamoe.mirai.event.events.BotReloginEvent;
-import net.mamoe.mirai.message.FriendMessageEvent;
-import net.mamoe.mirai.message.GroupMessageEvent;
+import net.mamoe.mirai.event.events.FriendMessageEvent;
+import net.mamoe.mirai.event.events.GroupMessageEvent;
 
-public class EventHandle implements ListenerHost {
+public class EventHandle extends SimpleListenerHost {
+	
+	public static final EventHandle INSTANCE = new EventHandle();
 	
 	@EventHandler
 	public void onGroupMessage(GroupMessageEvent event) {

--- a/src/main/java/cc/sukazyo/icee/module/bot/mirai/MiraiQQ.java
+++ b/src/main/java/cc/sukazyo/icee/module/bot/mirai/MiraiQQ.java
@@ -6,8 +6,7 @@ import cc.sukazyo.icee.system.Conf;
 import cc.sukazyo.icee.system.Log;
 import kotlinx.coroutines.Job;
 import net.mamoe.mirai.Bot;
-import net.mamoe.mirai.BotFactoryJvm;
-import net.mamoe.mirai.event.Events;
+import net.mamoe.mirai.BotFactory;
 import net.mamoe.mirai.utils.BotConfiguration;
 import net.mamoe.mirai.utils.LoggerAdapters;
 
@@ -24,8 +23,8 @@ public class MiraiQQ implements IBot {
 		@Override
 		public void run() {
 			bot.login();
-			Events.registerEvents(bot, new EventHandle());
-			bot.getFriend(863731218).sendMessage("HI,iCee!");
+			bot.getEventChannel().registerListenerHost(EventHandle.INSTANCE);
+			bot.getFriendOrFail(863731218).sendMessage("HI,iCee!");
 		}
 	}
 	
@@ -46,9 +45,10 @@ public class MiraiQQ implements IBot {
 		BotConfiguration conf = BotConfiguration.getDefault();
 		conf.setBotLoggerSupplier(bot1 -> LoggerAdapters.asMiraiLogger(Log.logger));
 		conf.setNetworkLoggerSupplier(bot1 -> LoggerAdapters.asMiraiLogger(Log.logger));
+		conf.setProtocol(BotConfiguration.MiraiProtocol.ANDROID_PAD);
 		
 		// 生成 bot 实例
-		return BotFactoryJvm.newBot(
+		return BotFactory.INSTANCE.newBot(
 				Conf.conf.getLong("module.bot.mirai.qqid"),
 				Conf.conf.getString("module.bot.mirai.password"),
 				conf

--- a/src/main/java/cc/sukazyo/icee/system/Conf.java
+++ b/src/main/java/cc/sukazyo/icee/system/Conf.java
@@ -79,7 +79,7 @@ public class Conf {
 						throw new ConfigException.Parse(def.origin(), "Unsupported key type " + def.getString(key + ".type") + " define found on " + key);
 				}
 			} catch (ConfigException.WrongType e) {
-				Log.logger.fatal(e.getMessage());
+				Log.logger.fatal(e.getMessage(), e);
 				System.exit(7);
 			} catch (ConfigException.Missing e) {
 				Log.logger.fatal("Missing Config " + key + "!", e);

--- a/src/main/java/cc/sukazyo/icee/system/Variable.java
+++ b/src/main/java/cc/sukazyo/icee/system/Variable.java
@@ -1,10 +1,10 @@
 package cc.sukazyo.icee.system;
 
-import cc.sukazyo.icee.module.bot.CommonBotMessage;
 import cc.sukazyo.icee.iCee;
+import cc.sukazyo.icee.module.bot.CommonBotMessage;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.mamoe.mirai.message.FriendMessageEvent;
-import net.mamoe.mirai.message.GroupMessageEvent;
+import net.mamoe.mirai.event.events.GroupMessageEvent;
+import net.mamoe.mirai.event.events.FriendMessageEvent;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/cc/sukazyo/icee/util/ConfigTypeHelper.java
+++ b/src/main/java/cc/sukazyo/icee/util/ConfigTypeHelper.java
@@ -44,7 +44,7 @@ public class ConfigTypeHelper {
 	 * @throws ConfigException.WrongType 类型检查失败
 	 */
 	public static void verifyLong (Config defaults, Config user, String key) throws ConfigException.WrongType {
-		defaults.getLong(key);
+		user.getLong(key);
 		if (defaults.hasPath(key + ".required") && (user.getLong(key) > defaults.getLongList(key + ".required").get(1) || user.getLong(key) < defaults.getLongList(key + ".required").get(0))) {
 			throw new ConfigException.WrongType(user.origin(), "value of " + key + " (" + user.getString(key) + ") exceeds the required range ( " + defaults.getStringList(key+".required").toString() + ")");
 		}


### PR DESCRIPTION
完成了 mirai 1.0 -> mirai 2.0 的迁移版本 ~~尽管是跳版本了不过就别关心这些了~~

也正式标志着失去 oracleJDK 支持了